### PR TITLE
Keep go mod to 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # go-sio
 
-Minimal helpers for streaming line-based IO in Go.
+Minimal helpers for streaming line-based IO in Go with no external dependencies.
 
-This small library provides utilities for reading streamed data line-by-line with configurable filtering, wrapping readers with closers, and a tee-style reader that captures the stream while still exposing an io.ReadCloser.
+This small library provides utilities for reading streamed data line-by-line with configurable filtering, wrapping readers with closers, and a tee-style reader that captures the stream while still exposing an io.ReadCloser. The package has no extra dependencies beyond the Go standard library.
 
 ## Key components
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/go-sio
 
-go 1.25.1
+go 1.24
+
+toolchain go1.24


### PR DESCRIPTION
Unless the new feature of 1.25 is been used, keep the go version to 1.24 so users can use it without extra checks.
