### PR TITLE
Upgrade/go 1.26 and update agents instruction to project level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
 
@@ -26,19 +26,21 @@ jobs:
         run: go mod tidy
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12
           only-new-issues: true
 
       - name: Run unit tests
-        run: go test -count=1 -v -race ./... -coverprofile=coverage.txt
+        run: |
+          go test -count=1 -v -race ./... -coverprofile=coverage.txt
+          go tool cover -func=coverage.txt | grep -qE '^total:.*100\.0%$'
 
       - name: Run benchmarks (no unit tests)
         run: go test -bench . -run '^$' ./...
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: maxwu/go-sio

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# go-sio
+
+A Go library for streaming I/O utilities.
+
+## Project Rules
+
+- **No third-party dependencies** — use only Go standard library.
+- **Test coverage must be 100%** — all code must be covered by unit tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-See [AGENTS.md](./AGENTS.md) for project instructions.
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# go-sio
+
+A Go library for streaming I/O utilities.
+
+## Project Rules
+
+- **No third-party dependencies** — use only Go standard library.
+- **Test coverage must be 100%** — all code must be covered by unit tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,1 @@
-# go-sio
-
-A Go library for streaming I/O utilities.
-
-## Project Rules
-
-- **No third-party dependencies** — use only Go standard library.
-- **Test coverage must be 100%** — all code must be covered by unit tests.
+See [AGENTS.md](./AGENTS.md) for project instructions.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,0 +1,1 @@
+See [CLAUDE.md](./CLAUDE.md) for project instructions.

--- a/CODEX.md
+++ b/CODEX.md
@@ -1,1 +1,0 @@
-See [CLAUDE.md](./CLAUDE.md) for project instructions.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ fmt.Print(string(b))
 - NewStreamReader will return nil when passed a nil reader — callers should check for this.
 - StreamReader's Read returns ErrNilReader (from the package) if the receiver is nil.
 
+## Development
+
+See [CLAUDE.md](./CLAUDE.md) for project rules and constraints.
+
 ## Contributing
 
 Contributions are welcome. Please open issues or pull requests for bugs, feature requests, or improvements.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ fmt.Print(string(b))
 
 ## Development
 
-See [CLAUDE.md](./CLAUDE.md) for project rules and constraints.
+See [AGENTS.md](./AGENTS.md) for project rules and constraints.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/maxwu/go-sio
 
-go 1.24
+go 1.26

--- a/s_reader_test.go
+++ b/s_reader_test.go
@@ -249,7 +249,7 @@ func TestStreamReader_Read_NoFinalNewline(t *testing.T) {
 
 	// Should return EOF on next read
 	buf = make([]byte, 10)
-	n, err = sr.Read(buf)
+	_, err = sr.Read(buf)
 	if err != io.EOF {
 		t.Errorf("Expected EOF, got %v", err)
 	}


### PR DESCRIPTION
- Update go.mod to use Go 1.26
- All tests pass with 100% coverage

Quick chore made with GLM-5 model.

Co-Authored-By: Claude <noreply@anthropic.com>